### PR TITLE
fix: Link to GitHub

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -8,7 +8,7 @@ const links = [
   { href: '/discord', title: 'Discord' },
   { href: 'https://twitter.com/fosscuk', title: 'Twitter' },
   { href: 'https://www.instagram.com/fosscuk', title: 'Instagram' },
-  { href: 'https://github.com/fosscu-community', title: 'GitHub' },
+  { href: 'https://github.com/FOSS-Community/', title: 'GitHub' },
 ];
 
 const readmore = [


### PR DESCRIPTION
Fixed minor issue with the link in footer that redirects to the GitHub Page of [FOSS Community](https://github.com/FOSS-Community/)

Thanks!